### PR TITLE
Make links match those we provide in Discord

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 # XMTP: Web3’s secure messaging network and protocol
 
-✨ Built with XMTP: https://xmtp.org/apps
+✨ Built with XMTP: <https://xmtp.org/apps>
 
 🥷🏻 Hackathons: https://xmtp.org/hackathons
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -4,7 +4,7 @@
 
 🥷🏻 Hackathons: <https://xmtp.org/hackathons>
 
-📚 Tutorials: https://xmtp.org/tutorials
+📚 Tutorials: <https://xmtp.org/tutorials>
 
 💨 Quickstart: https://xmtp.org/start
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,13 +1,11 @@
-# XMTP: the web3 messaging protocol
+# XMTP: Web3’s secure messaging network and protocol
 
-📚 Read [our docs](https://docs.xmtp.org) on how to start building with XMTP
+✨ Built with XMTP: https://xmtp.org/apps
 
-💬 Check out the [Quickstart React chat app](https://github.com/xmtp/xmtp-quickstart-react), demonstrating core capabilities of the XMTP client SDK
+🥷🏻 Hackathons: https://xmtp.org/hackathons
 
-💬 Check out the [XMTP Inbox chat app](https://github.com/xmtp-labs/xmtp-inbox-web), demonstrating core and advanced capabilities of the XMTP client SDK
+📚 Tutorials: https://xmtp.org/tutorials
 
-💾 Explore our [JavaScript SDK](https://github.com/xmtp/xmtp-js) for building messaging experiences that use XMTP
+💨 Quickstart: https://xmtp.org/start
 
-📜 Read our [XMTP Improvement Proposals (XIPs)](https://github.com/xmtp/XIPs)
-
-🐦 Follow [@xmtp_](https://twitter.com/xmtp_) on Twitter
+📖 Docs: https://xmtp.org/docs

--- a/profile/README.md
+++ b/profile/README.md
@@ -6,6 +6,6 @@
 
 📚 Tutorials: <https://xmtp.org/tutorials>
 
-💨 Quickstart: https://xmtp.org/start
+💨 Quickstart: <https://xmtp.org/start>
 
 📖 Docs: https://xmtp.org/docs

--- a/profile/README.md
+++ b/profile/README.md
@@ -2,7 +2,7 @@
 
 ✨ Built with XMTP: <https://xmtp.org/apps>
 
-🥷🏻 Hackathons: https://xmtp.org/hackathons
+🥷🏻 Hackathons: <https://xmtp.org/hackathons>
 
 📚 Tutorials: https://xmtp.org/tutorials
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -8,4 +8,4 @@
 
 💨 Quickstart: <https://xmtp.org/start>
 
-📖 Docs: https://xmtp.org/docs
+📖 Docs: <https://xmtp.org/docs>


### PR DESCRIPTION
- Per Fabri, let's make the links in the XMTP org README match the links we provide in Discord
- Updated page title to reflect the latest XMTP key messaging